### PR TITLE
Changes in std.mem.Allocator interface

### DIFF
--- a/src/descriptors.zig
+++ b/src/descriptors.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const jui = @import("jui.zig");
 
 pub const MethodDescriptor = struct {
     const Self = @This();
@@ -169,7 +170,17 @@ fn parse_(allocator: std.mem.Allocator, reader: anytype) anyerror!?*Descriptor {
             var returnd = (try parse_(allocator, reader)).?;
 
             var x = try allocator.create(Descriptor);
-            x.* = .{ .method = .{ .parameters = params.toOwnedSlice(), .return_type = returnd } };
+            x.* = if (jui.is_zig_master) .{
+                .method = .{
+                    .parameters = try params.toOwnedSlice(),
+                    .return_type = returnd,
+                },
+            } else .{
+                .method = .{
+                    .parameters = params.toOwnedSlice(),
+                    .return_type = returnd,
+                },
+            };
             return x;
         },
         ')' => return null,

--- a/src/jui.zig
+++ b/src/jui.zig
@@ -5,9 +5,12 @@ pub const descriptors = @import("descriptors.zig");
 pub const Reflector = @import("Reflector.zig");
 const types = @import("types.zig");
 
-// Some break changes in zig 0.10.0-dev
-// This code must be removed once the 0.10 was released
-const is_zig_master = builtin.zig_version.major >= 0 and builtin.zig_version.minor >= 10;
+// We support Zig 0.9.1 (old stable), 0.10.0 (current stable) and 0.11.0-dev (latest master).
+// We also support both stage1 and stage2 compilers.
+// This can be simplified once we drop support for Zig 0.9.1 and stage1:
+pub const is_zig_9_1 = builtin.zig_version.major >= 0 and builtin.zig_version.minor == 9;
+pub const is_zig_master = builtin.zig_version.major >= 0 and builtin.zig_version.minor >= 11;
+pub const is_stage2 = @hasDecl(builtin, "zig_backend") and builtin.zig_backend != .stage1;
 
 pub usingnamespace types;
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -3,10 +3,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
-
-// builtin.zig_backend decl exists
-// This code must be removed once the 0.9.1 support is not necessary.
-const is_stage2 = @hasDecl(builtin, "zig_backend") and builtin.zig_backend != .stage1;
+const jui = @import("jui.zig");
 
 /// Stolen from https://github.com/ziglang/zig/pull/6272
 /// [1]extern struct isn't allowed, see https://github.com/ziglang/zig/issues/6535
@@ -231,7 +228,7 @@ pub const JNINativeMethod = extern struct {
 // Instead of using std.meta.FnPtr for each declaration,
 // Just duplicating all structs here, with fn(..) and *const fn
 // This way it's easier to just delete when stage1 was removed
-const JNINativeInterface = if (is_stage2)
+const JNINativeInterface = if (jui.is_stage2)
     extern struct {
         reserved0: ?*anyopaque,
         reserved1: ?*anyopaque,
@@ -711,7 +708,7 @@ else
 // Instead of using std.meta.FnPtr for each declaration,
 // Just duplicating all structs here, with fn(..) and *const fn
 // This way it's easier to just delete when stage1 was removed
-const JNIInvokeInterface = if (is_stage2)
+const JNIInvokeInterface = if (jui.is_stage2)
     extern struct {
         reserved0: ?*anyopaque,
         reserved1: ?*anyopaque,


### PR DESCRIPTION
- As in Zig 0.11.0-dev, allocator.shrink() can fail, and functions such as `toOwnedSlice` had breaking changes too.
- Document all Zig version checks together in jui.zig.